### PR TITLE
MPU IRQ2 is valid on an XT

### DIFF
--- a/src/hardware/mpu401.cpp
+++ b/src/hardware/mpu401.cpp
@@ -759,17 +759,22 @@ public:
 
         if (IS_PC98_ARCH)
             mpu.irq=6;  /* This is said to be the MIDI card's factory default on PC-98 */
+        else if (CPU_ArchitectureType == CPU_ARCHTYPE_8086)
+            mpu.irq=2;  /* Default IRQ for the original Roland interface units */
         else
     		mpu.irq=9;	/* Princess Maker 2 wants it on irq 9 */
 
+        int x = section->Get_int("mpuirq");
+
+        if (!IS_PC98_ARCH && CPU_ArchitectureType == CPU_ARCHTYPE_8086)
         {
-            int x = section->Get_int("mpuirq");
-
-            if (x >= 2)
+            if (x >= 2 && x <= 7) /* Only one PIC on a XT */
                 mpu.irq = (unsigned int)x;
-
-            if (!IS_PC98_ARCH && mpu.irq == 2) mpu.irq = 9;
         }
+        else if (x >= 2) /* if mpuirq > 15, mpuirq = 15 */
+            mpu.irq = (unsigned int)x;
+
+        if (!IS_PC98_ARCH && mpu.irq == 2 && CPU_ArchitectureType != CPU_ARCHTYPE_8086) mpu.irq = 9;
 
         LOG(LOG_MISC,LOG_NORMAL)("MPU IRQ %d",(int)mpu.irq);
 


### PR DESCRIPTION
The original Roland interfaces used IRQ2, and this is valid for an XT which only has one PIC.
Set the default IRQ for an XT to IRQ2 and if MPUIRQ > 7, ignore it.

Does a 80186 have one or two PICs? This patch assumes it is the same as the 80286.

# Description

_Summary of changes brought by this PR._


**Does this PR address some issue(s) ?**

_Add the issue(s) fixed, e.g. ```#1234```_


**Does this PR introduce new feature(s) ?**

_Describe the feature(s) introduced._


**Are there any breaking changes ?**

_Describe the breaking changes in detail._


**Additional information**

_Add any additional information that may be useful._
